### PR TITLE
#19 update getall streamers api

### DIFF
--- a/backend/api/routes/connections.js
+++ b/backend/api/routes/connections.js
@@ -5,7 +5,23 @@ const router = express.Router(); //making a router
 
 //Route will add a connection to the database table 
 router.route("/add").post(authenticateMiddleware, async (req, res) => {
+  try{
+    const { connected_streamer_id} = req.body;
+    const user_id = req.user.id;
+    const supabaseClient = req.supabase
 
+    const { error } = await supabaseClient.from('connections').insert({ 
+        user_id: user_id, 
+        connected_streamer_id: connected_streamer_id 
+      });
+
+
+
+
+
+
+
+  }
 
 
 })

--- a/backend/api/routes/connections.js
+++ b/backend/api/routes/connections.js
@@ -2,30 +2,26 @@ const express = require("express");
 const { authenticateMiddleware } = require("../../middleware/authRequest");
 const router = express.Router(); //making a router
 
-
-//Route will add a connection to the database table 
+//Route will add a connection to the database table
 router.route("/add").post(authenticateMiddleware, async (req, res) => {
-  try{
-    const { connected_streamer_id} = req.body;
+  try {
+    const { connected_streamer_id } = req.body;
     const user_id = req.user.id;
-    const supabaseClient = req.supabase
+    const supabaseClient = req.supabase;
 
-    const { error } = await supabaseClient.from('connections').insert({ 
-        user_id: user_id, 
-        connected_streamer_id: connected_streamer_id 
-      });
+    const { error } = await supabaseClient.from("connections").insert({
+      user_id: user_id,
+      connected_streamer_id: connected_streamer_id,
+    });
 
+    if (error) throw error;
 
-
-
-
-
-
+    //201 status code signifies successful creation of a connection
+    res.status(201).json({ success: true, message: "Connection created" });
+  } catch (err) {
+    console.error("Error creating connection:", err);
+    res.status(500).json({ error: "Failed to create connection" });
   }
-
-
-})
-
-
+});
 
 module.exports = router;

--- a/backend/api/routes/connections.js
+++ b/backend/api/routes/connections.js
@@ -1,0 +1,15 @@
+const express = require("express");
+const { authenticateMiddleware } = require("../../middleware/authRequest");
+const router = express.Router(); //making a router
+
+
+//Route will add a connection to the database table 
+router.route("/add").post(authenticateMiddleware, async (req, res) => {
+
+
+
+})
+
+
+
+module.exports = router;

--- a/backend/api/routes/index.js
+++ b/backend/api/routes/index.js
@@ -1,9 +1,11 @@
 const express = require("express")
 const authRouter = require("./auth"); 
 const userRouter = require("./users");
+const connectionsRouter = require("./connections");
 const router = express.Router(); 
 
 router.use("/auth", authRouter); //mount the requests in authRoute file to correspond to /auth
 router.use("/users", userRouter);
+router.use("/connections", connectionsRouter); 
 
 module.exports = router;

--- a/backend/api/routes/users.js
+++ b/backend/api/routes/users.js
@@ -46,9 +46,19 @@ router.route("/get-all").get(authenticateMiddleware, async (req, res) => {
       throw new Error("Error fetching the current user", userErr);
     }
 
-    //TODO: ONCE SAVED CONNECTIONS IS IMPLEMENTED (THE PAGE) we need to filter out and only display streamers the user has not connected with. Dont want to display current connections on the discover page.
-    //fetch all profile rows
-    const { data: streamers, streamersError } = await supabase
+    //get the connections this user has. We get connections from connections table and select the connected streamer id whenever that connection's user_id matches ours
+    const { data: connections } = await supabase.from(
+      "connections".select("connected_streamer_id").eq("user_id", userId)
+    );
+
+    //just to make our life easier map through connections cause each itme in it is a database object. just extract the id and put it in a new array.
+    const connectedStreamersIds = connections.map(
+      (c) => c.connected_streamer_id
+    );
+    
+
+
+    let query = supabase
       .from("profiles")
       .select("*")
       //neq means select all profiles that arent equal to current user session id. We dont want oursevles showing up in recommendation

--- a/backend/api/routes/users.js
+++ b/backend/api/routes/users.js
@@ -45,6 +45,8 @@ router.route("/get-all").get(authenticateMiddleware, async (req, res) => {
     if (userErr) {
       throw new Error("Error fetching the current user", userErr);
     }
+
+    //TODO: ONCE SAVED CONNECTIONS IS IMPLEMENTED (THE PAGE) we need to filter out and only display streamers the user has not connected with. Dont want to display current connections on the discover page.
     //fetch all profile rows
     const { data: streamers, streamersError } = await supabase
       .from("profiles")

--- a/backend/services/calculateMatchScore.js
+++ b/backend/services/calculateMatchScore.js
@@ -1,5 +1,10 @@
 const { differenceInYears } = require("date-fns");
 
+// Age difference thresholds (in years)
+const VERY_CLOSE_AGE_THRESHOLD = 2;
+const CLOSE_AGE_THRESHOLD = 5;
+const SOMEWHAT_CLOSE_AGE_THRESHOLD = 10;
+
 //function returns the match score between the currentUser and a streamer based off values. The higher the score the better the match
 function calculateMatchScore(currentUser, streamerToCompare) {
   //to start off score can only go up.
@@ -18,19 +23,20 @@ function calculateMatchScore(currentUser, streamerToCompare) {
   //get the age difference and depending on how far the gap is we assign more points if the gap is closer and less if further apart
   const ageDifference = Math.abs(currentUserAge - streamerAge);
 
-  if (ageDifference <= 2) {
+  if (ageDifference <= VERY_CLOSE_AGE_THRESHOLD) {
     score += 4;
-  } else if (ageDifference <= 5) {
+  } else if (ageDifference <= CLOSE_AGE_THRESHOLD) {
     score += 2;
-  } else if (ageDifference <= 10) {
+  } else if (ageDifference <= SOMEWHAT_CLOSE_AGE_THRESHOLD) {
     score++;
   }
 
-  //check targetAudience. This one is a BIG boost. If user and streamer we are comparing them with stream to same audience give them 3 points
+  //check targetAudience. This one is a BIG boost. If user and streamer we are comparing them with stream to same audience give them 6 points
   if (currentUser.targetAudience === streamerToCompare.targetAudience) {
     score += 6;
   }
 
+  //TODO: CASE INSENSITIVITY if user has tag "valorant" vs "Valorant" should still match
   //Now we need to check tags. We can add points depending on how many tags are shared between the user and the streamer we are checking
   //filter through current users tags and return tags that are in the streamerTocompare tags
   const sharedTags = currentUser.tags.filter( (tag) => {

--- a/frontend/src/components/DiscoverStreamerCard/DiscoverStreamerCard.tsx
+++ b/frontend/src/components/DiscoverStreamerCard/DiscoverStreamerCard.tsx
@@ -5,7 +5,7 @@ import { Heart, X, Users } from "lucide-react";
 //library with a function that can calculate the difference in years from today and someones birthday
 import { differenceInYears } from "date-fns";
 
-import type { StreamerProfile } from "@/Types/AppTypes";
+import type { StreamerProfile } from "@/types/AppTypes";
 
 type DisoverStreamerCardProps = {
   streamer: StreamerProfile;

--- a/frontend/src/components/DiscoverStreamerCard/DiscoverStreamerCard.tsx
+++ b/frontend/src/components/DiscoverStreamerCard/DiscoverStreamerCard.tsx
@@ -78,12 +78,25 @@ export default function DiscoverStreamerCard({
         </div>
       </CardContent>
       <CardFooter className='flex justify-between'>
-        <Button onClick = {() => onStreamerConnectClick(streamer.id)} variant='ghost' className='cursor-pointer'>
+        <Button
+          onClick={e => {
+            e.stopPropagation();
+            onStreamerConnectClick(streamer.id);
+          }}
+          variant='ghost'
+          className='cursor-pointer'
+        >
           <Heart className='h-3 w-3' />
           <span className='text-sm'>Connect</span>
         </Button>
 
-        <Button variant='ghost' className='cursor-pointer text-red-500 hover:text-red-500'>
+        <Button
+          onClick={e => {
+            e.stopPropagation();
+          }}
+          variant='ghost'
+          className='cursor-pointer text-red-500 hover:text-red-500'
+        >
           <X className='h-3 w-3' />
           <span className='text-sm'>Not Interested</span>
         </Button>

--- a/frontend/src/components/DiscoverStreamerCard/DiscoverStreamerCard.tsx
+++ b/frontend/src/components/DiscoverStreamerCard/DiscoverStreamerCard.tsx
@@ -10,11 +10,13 @@ import type { StreamerProfile } from "@/types/AppTypes";
 type DisoverStreamerCardProps = {
   streamer: StreamerProfile;
   onStreamerClick: (profile: StreamerProfile) => void;
+  onStreamerConnectClick: (streamerToConnectId: string) => void;
 };
 
 export default function DiscoverStreamerCard({
   streamer,
   onStreamerClick,
+  onStreamerConnectClick,
 }: DisoverStreamerCardProps) {
   //using the date-fns library function differenceInYears to calculate someones age based on todays date and date_of_birth
   const age = differenceInYears(new Date(), new Date(streamer.date_of_birth));
@@ -76,7 +78,7 @@ export default function DiscoverStreamerCard({
         </div>
       </CardContent>
       <CardFooter className='flex justify-between'>
-        <Button variant='ghost' className='cursor-pointer'>
+        <Button onClick = {() => onStreamerConnectClick(streamer.id)} variant='ghost' className='cursor-pointer'>
           <Heart className='h-3 w-3' />
           <span className='text-sm'>Connect</span>
         </Button>

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -71,7 +71,7 @@ export default function Layout() {
           </NavigationMenuItem>
         </NavigationMenuList>
 
-        <Button >
+        <Button className ="position absolute right-6 cursor-pointer hover:scale-105 transition-transform duration-200" variant = "destructive" onClick = {signOut}>
           <LogOut/>
         </Button>
 

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -2,6 +2,8 @@
 import { Outlet } from "react-router-dom";
 import { useNavigate, useLocation } from "react-router-dom";
 import { DASHBOARD_PATH, DISCOVER_PATH, CONNECTIONS_PATH, EVENTS_PATH } from "@/lib/paths";
+import { LogOut } from "lucide-react"
+import { useAuthContext } from "@/Context/AuthProvider";
 
 import {
   NavigationMenu,
@@ -10,7 +12,11 @@ import {
   NavigationMenuList,
 } from "@/components/ui/navigation-menu";
 
+import { Button } from "../ui/button";
+
 export default function Layout() {
+
+  const {signOut} = useAuthContext(); //grabbing the signOut function from our context so when button is clicked we can call the function
   const location = useLocation(); //using location to figure out what path we are currently on to highlight it to user
   const navigate = useNavigate();
 
@@ -64,6 +70,12 @@ export default function Layout() {
             </NavigationMenuLink>
           </NavigationMenuItem>
         </NavigationMenuList>
+
+        <Button >
+          <LogOut/>
+        </Button>
+
+
       </NavigationMenu>
       <Outlet />
     </div>

--- a/frontend/src/components/StreamerCard/StreamerCard.tsx
+++ b/frontend/src/components/StreamerCard/StreamerCard.tsx
@@ -1,6 +1,6 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "../ui/button";
-import type { StreamerProfile } from "@/Types/AppTypes";
+import type { StreamerProfile } from "@/types/AppTypes";
 
 type StreamerCardProps = {
   profile: StreamerProfile;

--- a/frontend/src/components/StreamerGrid/StreamerGrid.tsx
+++ b/frontend/src/components/StreamerGrid/StreamerGrid.tsx
@@ -1,5 +1,5 @@
 import DiscoverStreamerCard from "../DiscoverStreamerCard/DiscoverStreamerCard";
-import type { StreamerProfile } from "@/Types/AppTypes";
+import type { StreamerProfile } from "@/types/AppTypes";
 
 type StreamerGridProps = {
   handleStreamerClick: (profile: StreamerProfile) => void;

--- a/frontend/src/components/StreamerGrid/StreamerGrid.tsx
+++ b/frontend/src/components/StreamerGrid/StreamerGrid.tsx
@@ -3,12 +3,14 @@ import type { StreamerProfile } from "@/types/AppTypes";
 
 type StreamerGridProps = {
   handleStreamerClick: (profile: StreamerProfile) => void;
+  handleStreamerConnect: (streamerToConnectId: string) => void;
   recommendedStreamers: StreamerProfile[];
 };
 
 //TODO: In a future branch StreamerGrid will be called from Disover page and will be passes information fetched from database after algorithm..
 export default function StreamerGrid({
   handleStreamerClick,
+  handleStreamerConnect,
   recommendedStreamers,
 }: StreamerGridProps) {
   return (
@@ -20,6 +22,7 @@ export default function StreamerGrid({
           key={streamer.id}
           streamer={streamer}
           onStreamerClick={handleStreamerClick}
+          onStreamerConnectClick = {handleStreamerConnect}
         />
       ))}
     </div>

--- a/frontend/src/lib/api_client.ts
+++ b/frontend/src/lib/api_client.ts
@@ -45,3 +45,28 @@ export async function fetchRecommendedStreamers(accessToken: string) {
     throw new Error("Unable to fetch streamers");
   }
 }
+
+//function makes fetch request to the api that posts a connection on the database
+export async function postStreamerConnection(accessToken: string, streamerId: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/connections/add`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      //pass in the request body the id of the streamer user is connecting with
+      body: JSON.stringify({ connected_streamer_id: streamerId }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Failed to connect with the streamer: ${res.status}`);
+    }
+
+    const result = await res.json();
+    return result;
+  } catch (err) {
+    console.error(`Could not create connection`, err);
+    throw new Error("Unable to create connection");
+  }
+}

--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -13,6 +13,9 @@ export default function DashboardPage() {
   const [userProfile, setUserProfile] = useState(null);
   const [loading, setLoading] = useState(true);
 
+  //TODO: Remove later, leaving this here for now so that it is easier to test my apis. Whenever I test them since they have middleware I need to provide a token this is how I see and get that token.
+  console.log(session?.access_token);
+
   useEffect(() => {
     async function populateStreamerCard() {
       //once there is a session setLoading to true so we can display loading text since we are checking profile

--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -57,8 +57,12 @@ export default function DashboardPage() {
       <div className='flex flex-1 flex-col-reverse items-center gap-6'>
         {/*Prompt of day and recent avtiviy components go here */}
 
-        <Button className = "h-16 w-72 cursor-pointer transition-transform duration-200 ease-in-out hover:scale-105" variant = "destructive" onClick = {signOut}>
-          <LogOut/>
+        <Button
+          className='h-16 w-72 cursor-pointer transition-transform duration-200 ease-in-out hover:scale-105'
+          variant='destructive'
+          onClick={signOut}
+        >
+          <LogOut />
           Logout
         </Button>
         <Button

--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -5,10 +5,11 @@ import { DISCOVER_PATH } from "@/lib/paths";
 import StreamerCard from "@/components/StreamerCard/StreamerCard";
 import { fetchStreamerInfo } from "@/lib/api_client";
 import { useAuthContext } from "@/Context/AuthProvider";
+import { LogOut } from "lucide-react";
 
 export default function DashboardPage() {
   const navigate = useNavigate();
-  const { session } = useAuthContext();
+  const { session, signOut } = useAuthContext();
   const [userProfile, setUserProfile] = useState(null);
   const [loading, setLoading] = useState(true);
 
@@ -56,11 +57,15 @@ export default function DashboardPage() {
       <div className='flex flex-1 flex-col-reverse items-center gap-6'>
         {/*Prompt of day and recent avtiviy components go here */}
 
+        <Button className = "h-16 w-72 cursor-pointer transition-transform duration-200 ease-in-out hover:scale-105" variant = "destructive" onClick = {signOut}>
+          <LogOut/>
+          Logout
+        </Button>
         <Button
           onClick={() => {
             navigate(DISCOVER_PATH);
           }}
-          className='position bg-electric-indigo h-16 w-72 cursor-pointer transition-transform duration-200 ease-in-out hover:scale-105'
+          className='bg-electric-indigo h-16 w-72 cursor-pointer transition-transform duration-200 ease-in-out hover:scale-105'
         >
           Discover Streamers!
         </Button>

--- a/frontend/src/pages/DiscoverPage/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage/DiscoverPage.tsx
@@ -3,7 +3,7 @@ import StreamerGrid from "@/components/StreamerGrid/StreamerGrid";
 import StreamerCard from "@/components/StreamerCard/StreamerCard";
 import { fetchRecommendedStreamers } from "@/lib/api_client";
 import { useAuthContext } from "@/Context/AuthProvider";
-import type { StreamerProfile } from "@/Types/AppTypes";
+import type { StreamerProfile } from "@/types/AppTypes";
 
 export default function DiscoverPage() {
   const { session } = useAuthContext();

--- a/frontend/src/pages/DiscoverPage/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage/DiscoverPage.tsx
@@ -26,6 +26,10 @@ export default function DiscoverPage() {
     setSelectedStreamer(null);
   }
 
+  function handleStreamerConnect(streamerToConnectId){
+
+  }
+
   //Stretch maybe in future add a not interested and connect button inside modal but for now click will just be detailed view
   //and user has to click out to connect or be not interested.
 
@@ -45,6 +49,7 @@ export default function DiscoverPage() {
       <StreamerGrid
         handleStreamerClick={handleStreamerClick}
         recommendedStreamers={recommendedStreamers}
+        handleStreamerConnect = {handleStreamerConnect}
       />
 
       {/*Below is modal view we only want it to render if a card is clicked and we call the handleStreamerClick and it setSelectedStreamer to be a profile */}

--- a/frontend/src/pages/DiscoverPage/DiscoverPage.tsx
+++ b/frontend/src/pages/DiscoverPage/DiscoverPage.tsx
@@ -32,13 +32,7 @@ export default function DiscoverPage() {
     //useAuthContext takes care of this but if I dont include this check ts whines
     if (!session?.access_token) return;
     try {
-      const res = await postStreamerConnection(session?.access_token, streamerToConnectId);
-
-      if (!res.ok) {
-        throw new Error("Failed to fetch connect api");
-      }
-
-      const data = await res.json(); //parsing
+      const data = await postStreamerConnection(session?.access_token, streamerToConnectId);
 
       //if success field is true it means we added a connection then filter out the connection we just added from our recommnededStreamers grid
       if (data.success) {


### PR DESCRIPTION
### Before and After Product Change

_Before_

On page navigation users we connected with would show up again on the discover page. (Manuel suggested to change this earlier on in feedback)

_After_

https://github.com/user-attachments/assets/b8edcaae-0ee2-4722-87c0-f32d1acd2ea1


**Context**
This pull request fixes the persistent recommendation issue for StreamNet.

**This Pull Request**
- Added connection filtering to /get-all endpoint - Excludes already-connected streamers from recommendations
- Fixed recommendation persistence bug - Connected streamers no longer reappear on page refresh or navigation
- Implemented Supabase .not() filtering - Uses existing connections data to filter out connected streamer IDs

**Next Pull Request**
- Will create GET connections API route