### PR TITLE
#27 tc1 algorithm improving audience weight

### DIFF
--- a/backend/api/routes/userActions.js
+++ b/backend/api/routes/userActions.js
@@ -42,12 +42,23 @@ router.route("/connect").post(authenticateMiddleware, async (req, res) => {
     const gameMatch = calcGameScore(user, streamer) > 1;
     const audienceMatch = calcAudienceScore(user, streamer) > 1;
 
-    //now after we checked why user connected with this streamer. Did he give importance to languages matching, games matching, audiences matching?
+    //now after we checked why user connected with this streamer. Did he give importance to languages matching, games matching, age?
     //we update all the weights based on the matching
     if (ageClose) userWeights.age_weight += 0.1;
-    if (audienceMatch) userWeights.audience_weight += 0.1;
     if (gameMatch) userWeights.game_weight += 0.1;
     if (languageMatch) userWeights.language_weight += 0.1;
+
+    //Below two weight updates since they arent something as binary as same language or range of age we update based on user preference
+    //below json in database contains all the possible audiences parse it to make it an object
+    const audiencePreferences = JSON.parse(userWeights.audience_preferences || {}) 
+
+    const streamerAudience = streamer.targetAudience  //get what audience the streamer streams too
+
+    //since when users sign up they have a dropdown list of audiences streamers audience will always exist in our JSON of audience preference weights
+
+    //increase the weight of that streamer's audience in our preferences because if we connected with a mature streamer it is because we want to see more of those.
+    audiencePreferences[streamerAudience] += 0.1;
+
 
     //we need to make a bigger array of tags based off the tags the user has on our platform combined with their tags on twitch that they dont know we are using shhhh
     const allTags = [...(streamer.tags || []), ...(streamer.twitch_tags || [])];
@@ -71,7 +82,7 @@ router.route("/connect").post(authenticateMiddleware, async (req, res) => {
       .from("user_weights")
       .update({
         age_weight: userWeights.age_weight,
-        audience_weight: userWeights.audience_weight,
+        audience_preferences: JSON.stringify(audiencePreferences),
         game_weight: userWeights.game_weight,
         language_weight: userWeights.language_weight,
         preferred_tags: userWeights.preferred_tags,

--- a/backend/api/routes/userActions.js
+++ b/backend/api/routes/userActions.js
@@ -3,7 +3,6 @@ const { authenticateMiddleware } = require("../../middleware/authRequest");
 const router = express.Router(); //making a router
 const {
   calcAgeScore,
-  calcAudienceScore,
   calcLanguageScore,
   calcGameScore,
 } = require("../../services/calculateMatchScore.js");
@@ -40,7 +39,6 @@ router.route("/connect").post(authenticateMiddleware, async (req, res) => {
     //same thing language matches if calc language checks them and they return greater than 1 cause they are same
     const languageMatch = calcLanguageScore(user, streamer) > 1;
     const gameMatch = calcGameScore(user, streamer) > 1;
-    const audienceMatch = calcAudienceScore(user, streamer) > 1;
 
     //now after we checked why user connected with this streamer. Did he give importance to languages matching, games matching, age?
     //we update all the weights based on the matching
@@ -49,16 +47,13 @@ router.route("/connect").post(authenticateMiddleware, async (req, res) => {
     if (languageMatch) userWeights.language_weight += 0.1;
 
     //Below two weight updates since they arent something as binary as same language or range of age we update based on user preference
-    //below json in database contains all the possible audiences parse it to make it an object
-    const audiencePreferences = JSON.parse(userWeights.audience_preferences || {}) 
-
-    const streamerAudience = streamer.targetAudience  //get what audience the streamer streams too
+    //dont need to parse audience_preferences I forgot supabase returns it as an object already not a string
+    const audiencePreferences = userWeights.audience_preferences;
+    const streamerAudience = streamer.targetAudience; //get what audience the streamer streams too
 
     //since when users sign up they have a dropdown list of audiences streamers audience will always exist in our JSON of audience preference weights
-
     //increase the weight of that streamer's audience in our preferences because if we connected with a mature streamer it is because we want to see more of those.
     audiencePreferences[streamerAudience] += 0.1;
-
 
     //we need to make a bigger array of tags based off the tags the user has on our platform combined with their tags on twitch that they dont know we are using shhhh
     const allTags = [...(streamer.tags || []), ...(streamer.twitch_tags || [])];
@@ -82,7 +77,7 @@ router.route("/connect").post(authenticateMiddleware, async (req, res) => {
       .from("user_weights")
       .update({
         age_weight: userWeights.age_weight,
-        audience_preferences: JSON.stringify(audiencePreferences),
+        audience_preferences: audiencePreferences,
         game_weight: userWeights.game_weight,
         language_weight: userWeights.language_weight,
         preferred_tags: userWeights.preferred_tags,


### PR DESCRIPTION
Cannot really add pictures because this update didn't give me a noticeable change in the actual web app. 

<img width="313" height="354" alt="Screenshot 2025-07-10 at 5 19 24 PM" src="https://github.com/user-attachments/assets/271a310d-7aad-43dd-a45f-a0fa3da5aa0d" />

(updated audience preferences in data table tho)


**This Pull Request:**
- Modified calcAudienceScore() to use learned preferences instead of binary audience matching
- Added audience_preferences JSON field to user weights table with default values for all audience types
- Updated weight learning logic in /update-weight route to increase audience preferences when users connect
- Removed audience_weight multiplier since preferences are now built into the scoring
- Updated match score calculation to treat audience scores similar to tag scores

**Next Pull Request:** 
- Not Interested Feature - API Implementation