### PR TITLE
#67 filtering through backend seen logic

### DIFF
--- a/backend/api/routes/activity.js
+++ b/backend/api/routes/activity.js
@@ -30,3 +30,5 @@ router.route("/").post(authenticateMiddleware, async (req, res) => {
     });
   }
 });
+
+module.exports = router;

--- a/backend/api/routes/activity.js
+++ b/backend/api/routes/activity.js
@@ -1,0 +1,32 @@
+const express = require("express");
+const { authenticateMiddleware } = require("../../middleware/authRequest");
+const router = express.Router();
+
+//router posts a new activity on table
+router.route("/").post(authenticateMiddleware, async (req, res) => {
+  try {
+    const userId = req.user.id;
+    const supabaseClient = req.supabase;
+
+    const { activityType } = req.body;
+
+    const { error } = await supabaseClient.from("user_activity").insert({
+      user_id: userId,
+      activity_type: activityType,
+    });
+
+    if (error) {
+      throw new Error("Error inserting a user activity into table", error);
+    }
+
+    return res
+      .status(201)
+      .json({ message: "User Activity successfully logged" });
+  } catch (err) {
+    console.error("Error logging activity", err);
+    return res.status(500).json({
+      error: "Failed to log activity",
+      message: "Internal server error",
+    });
+  }
+});

--- a/backend/api/routes/auth.js
+++ b/backend/api/routes/auth.js
@@ -80,6 +80,19 @@ router
         console.warn("Failed to create user weights:", weightsError);
       }
 
+      const { error: notifSettingsError } = await req.supabase
+        .from("user_notification_settings")
+        .insert({
+          user_id: req.user.id,
+        });
+
+      if (notifSettingsError) {
+        console.warn(
+          "Failed to set a notification settings table for the user",
+          notifSettingsError
+        );
+      }
+
       return res.status(201).json({
         message: "Profile created successfully",
         profile,

--- a/backend/api/routes/index.js
+++ b/backend/api/routes/index.js
@@ -5,6 +5,7 @@ const connectionsRouter = require("./connections");
 const notinterestedRouter = require("./notinterested");
 const eventsRouter = require("./events");
 const notifRouter = require("./notifications");
+const activityRouter = require("./activity");
 const router = express.Router(); 
 
 router.use("/auth", authRouter); //mount the requests in authRoute file to correspond to /auth
@@ -13,5 +14,6 @@ router.use("/connections", connectionsRouter);
 router.use("/not-interested", notinterestedRouter);
 router.use("/events", eventsRouter);
 router.use("/notifications", notifRouter);
+router.use("/activity", activityRouter);
 
 module.exports = router;

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -50,4 +50,22 @@ router.route("/:id").put(authenticateMiddleware, async (req, res) => {
   }
 });
 
+router.route("/settings").get(authenticateMiddleware, async (req, res) =>{
+  try{
+
+
+
+
+  } catch(err){
+
+
+    
+  }
+
+
+
+
+
+})
+
 module.exports = router;

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -13,7 +13,24 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
       .eq("user_id", user_id)
       .single();
 
+    if(settingsError){
+      console.error("Error fetching notification settings:", settingsError);
+      return res.status(500).json({ error: "Failed to fetch settings" });
+    }
     
+    let enabledTypes = [];
+
+    //add types to array we will use this array in query
+    if (settings.connection_request_enabled) enabledTypes.push("connection_request");
+    if (settings.connection_accepted_enabled) enabledTypes.push("connection_accepted");
+    if (settings.connection_denied_enabled) enabledTypes.push("connection_denied");
+    if (settings.private_event_invitation_enabled) enabledTypes.push("private_event_invitation");
+    if (settings.event_rsvp_updates_enabled) enabledTypes.push("event_rsvp_updates");
+    if (settings.public_event_announcements_enabled) enabledTypes.push("public_event_announcement");
+    if (settings.network_event_announcements_enabled) enabledTypes.push("network_event_announcements");
+
+    
+
     const { data: notifications, error } = await supabaseClient
       .from("notifications")
       .select("*")

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -92,7 +92,7 @@ router.route("/settings").patch(authenticateMiddleware, async (req, res) => {
       network_event_announcements_enabled,
     } = req.body;
 
-    const { data: settings, error } = await supabaseClient
+    const { error } = await supabaseClient
       .from("user_notification_settings")
       .update({
         push_enabled,

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -6,7 +6,14 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
   try {
     const user_id = req.user.id;
     const supabaseClient = req.supabase;
+    
+    const { data: settings, error: settingsError } = await supabaseClient
+      .from("user_notification_settings")
+      .select("*")
+      .eq("user_id", user_id)
+      .single();
 
+    
     const { data: notifications, error } = await supabaseClient
       .from("notifications")
       .select("*")

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -11,7 +11,7 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
       .from("notifications")
       .select("*")
       .eq("user_id", user_id)
-      .neq("status", "read")
+      .in("status", ["delivered", "seen"]) //dont show read or pending ones (queued for smart delivery)
       .order("created_at", { ascending: false }); // Most recent first
 
     if (error) throw error;

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -6,30 +6,43 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
   try {
     const user_id = req.user.id;
     const supabaseClient = req.supabase;
-    
+
     const { data: settings, error: settingsError } = await supabaseClient
       .from("user_notification_settings")
       .select("*")
       .eq("user_id", user_id)
       .single();
 
-    if(settingsError){
+    if (settingsError) {
       console.error("Error fetching notification settings:", settingsError);
       return res.status(500).json({ error: "Failed to fetch settings" });
     }
-    
+
     let enabledTypes = [];
 
     //add types to array we will use this array in query
-    if (settings.connection_request_enabled) enabledTypes.push("connection_request");
-    if (settings.connection_accepted_enabled) enabledTypes.push("connection_accepted");
-    if (settings.connection_denied_enabled) enabledTypes.push("connection_denied");
-    if (settings.private_event_invitation_enabled) enabledTypes.push("private_event_invitation");
-    if (settings.event_rsvp_updates_enabled) enabledTypes.push("event_rsvp_updates");
-    if (settings.public_event_announcements_enabled) enabledTypes.push("public_event_announcement");
-    if (settings.network_event_announcements_enabled) enabledTypes.push("network_event_announcements");
+    if (settings.connection_request_enabled)
+      enabledTypes.push("connection_request");
+    if (settings.connection_accepted_enabled)
+      enabledTypes.push("connection_accepted");
+    if (settings.connection_denied_enabled)
+      enabledTypes.push("connection_denied");
+    if (settings.private_event_invitation_enabled)
+      enabledTypes.push("private_event_invitation");
+    if (settings.event_rsvp_updates_enabled)
+      enabledTypes.push("event_rsvp_updates");
+    if (settings.public_event_announcements_enabled)
+      enabledTypes.push("public_event_announcement");
+    if (settings.network_event_announcements_enabled)
+      enabledTypes.push("network_event_announcements");
 
-    
+    let priorityConditions = [];
+    if (settings.important_enabled) priorityConditions.push("immediate");
+    if (settings.general_enabled) priorityConditions.push("general");
+
+    if (enabledTypes.length === 0 || priorityConditions.length === 0) {
+      return res.status(200).json([]);
+    }
 
     const { data: notifications, error } = await supabaseClient
       .from("notifications")

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -85,8 +85,8 @@ router.route("/:id").put(authenticateMiddleware, async (req, res) => {
       .from("notifications")
       .update({
         status: status,
-        //if status for notif is that it was read then update read_at field will need this later for tracking when user is most active viewing notifs
-        read_at: status === "read" ? new Date().toISOString() : null,
+        //if status for notif is that it was seen then update seen_at field
+        seen_at: status === "seen" ? new Date().toISOString() : null,
       })
       .eq("id", id)
       .eq("user_id", user_id);

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -74,4 +74,20 @@ router.route("/settings").get(authenticateMiddleware, async (req, res) => {
   }
 });
 
+router.route("/settings").put(authenticateMiddleware, async(req, res) => {
+  const supabaseClient = req.supabase;
+  const userId = req.user.id;
+
+  try{
+
+
+  }catch(err){
+
+    
+  }
+
+
+  
+})
+
 module.exports = router;

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -44,6 +44,17 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
       return res.status(200).json([]);
     }
 
+    await supabaseClient
+      .from("notifications")
+      .update({
+        status: "seen",
+        seen_at: new Date().toISOString(),
+      })
+      .eq("user_id", user_id)
+      .eq("status", "delivered")
+      .in("type", enabledTypes)
+      .in("priority", priorityConditions);
+
     const { data: notifications, error } = await supabaseClient
       .from("notifications")
       .select("*")

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -50,22 +50,28 @@ router.route("/:id").put(authenticateMiddleware, async (req, res) => {
   }
 });
 
-router.route("/settings").get(authenticateMiddleware, async (req, res) =>{
-  try{
+router.route("/settings").get(authenticateMiddleware, async (req, res) => {
+  try {
+    const { data: settings, error } = await req.supabase
+      .from("user_notification_settings")
+      .select("*")
+      .eq("user_id", req.user.id)
+      .single();
 
+    if (error) {
+      throw new Error(
+        "Could not fetch the notification preferences for the user",
+        error
+      );
+    }
 
-
-
-  } catch(err){
-
-
-    
+    return res.status(200).json({ settings });
+  } catch (err) {
+    console.error("Could not fetch Notification Settings", err);
+    return res.status(500).json({
+      error: "Failed to fetch settings",
+    });
   }
-
-
-
-
-
-})
+});
 
 module.exports = router;

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -74,20 +74,54 @@ router.route("/settings").get(authenticateMiddleware, async (req, res) => {
   }
 });
 
-router.route("/settings").put(authenticateMiddleware, async(req, res) => {
+router.route("/settings").patch(authenticateMiddleware, async (req, res) => {
   const supabaseClient = req.supabase;
   const userId = req.user.id;
 
-  try{
+  try {
+    const {
+      push_enabled,
+      important_enabled,
+      general_enabled,
+      connection_request_enabled,
+      connection_accepted_enabled,
+      connection_denied_enabled,
+      private_event_invitation_enabled,
+      event_rsvp_updates_enabled,
+      public_event_announcements_enabled,
+      network_event_announcements_enabled,
+    } = req.body;
 
+    const { data: settings, error } = await supabaseClient
+      .from("user_notification_settings")
+      .update({
+        push_enabled,
+        important_enabled,
+        general_enabled,
+        connection_request_enabled,
+        connection_accepted_enabled,
+        connection_denied_enabled,
+        private_event_invitation_enabled,
+        event_rsvp_updates_enabled,
+        public_event_announcements_enabled,
+        network_event_announcements_enabled,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("user_id", userId);
 
-  }catch(err){
+    if (error) {
+      throw new Error("Error updating the notification settings", error);
+    }
 
-    
+    return res.status(200).json({
+      message: "Notification settings have been updated for user",
+    });
+  } catch (err) {
+    console.error("Error updating notification settings", err);
+    return res.status(500).json({
+      error: "Could not update notification settings",
+    });
   }
-
-
-  
-})
+});
 
 module.exports = router;

--- a/backend/api/routes/notifications.js
+++ b/backend/api/routes/notifications.js
@@ -30,7 +30,7 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
     if (settings.private_event_invitation_enabled)
       enabledTypes.push("private_event_invitation");
     if (settings.event_rsvp_updates_enabled)
-      enabledTypes.push("event_rsvp_updates");
+      enabledTypes.push("event_rsvp_update");
     if (settings.public_event_announcements_enabled)
       enabledTypes.push("public_event_announcement");
     if (settings.network_event_announcements_enabled)
@@ -59,7 +59,9 @@ router.route("/").get(authenticateMiddleware, async (req, res) => {
       .from("notifications")
       .select("*")
       .eq("user_id", user_id)
-      .in("status", ["delivered", "seen"]) //dont show read or pending ones (queued for smart delivery)
+      .in("status", ["seen"])
+      .in("type", enabledTypes)
+      .in("priority", priorityConditions)
       .order("created_at", { ascending: false }); // Most recent first
 
     if (error) throw error;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,8 +1,11 @@
 const dotenv = require("dotenv");
-dotenv.config(); 
-const express = require("express"); 
-const cors = require("cors"); 
+dotenv.config();
+const express = require("express");
+const cors = require("cors");
 const routes = require("./api/routes/index");
+const {
+  startGeneralNotificationScheduler,
+} = require("./services/notificationScheduler");
 
 const app = express(); //creating an instance of the express application
 app.use(
@@ -23,6 +26,7 @@ app.get("/", (req, res) => {
 
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
+  startGeneralNotificationScheduler();
 });
 
 module.exports = app;

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -1,0 +1,24 @@
+const { supabase } = require("../services/supabaseclient");
+
+//function will check activity table and times
+//to determine in what 3 hour interval user is the most
+//active
+async function calculateActiveWindow(userId) {
+  try {
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+    const { data: activities, error } = await supabase
+      .from("user_activity")
+      .select("created_at")
+      .eq("user_id", userId)
+      .gte("created_at", sevenDaysAgo.toISOString())
+      .order("created_at", { ascending: false });
+
+    if (error) throw error;
+
+    if (!activities || activities.length < 5) {
+      return { start: 19, end: 22, count: 0 };
+    }
+  } catch (err) {}
+}

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -78,10 +78,23 @@ async function updateUserActiveWindow(userId) {
 
 async function getUsersActiveWindow(userId) {
   try {
+
     const { data: user, error } = await supabase
       .from("profiles")
       .select("active_window_start, active_window_end, last_window_calculated")
       .eq("id", userId)
       .single();
+
+      if(error) throw error;
+
+      const sevenDaysAgo = new Date();
+      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+
+      const needsUpdate = !user.last_window_calculated || new Date(user.last_window_calculated) < sevenDaysAgo;
+
+      if(needsUpdate)
+        return await updateUserActiveWindow(userId);
+
+      
   } catch (err) {}
 }

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -20,5 +20,20 @@ async function calculateActiveWindow(userId) {
     if (!activities || activities.length < 5) {
       return { start: 19, end: 22, count: 0 };
     }
+
+    //we are working in military time
+    //making 8 windows (3 hour chunks)
+    //updating count whenever activity takes place
+    //within those windows
+    const windows = [
+      { start: 0, end: 3, count: 0 }, 
+      { start: 3, end: 6, count: 0 }, 
+      { start: 6, end: 9, count: 0 }, 
+      { start: 9, end: 12, count: 0 }, 
+      { start: 12, end: 15, count: 0 }, 
+      { start: 15, end: 18, count: 0 }, 
+      { start: 18, end: 21, count: 0 }, 
+      { start: 21, end: 24, count: 0 }, 
+    ];
   } catch (err) {}
 }

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -42,6 +42,11 @@ async function calculateActiveWindow(userId) {
       if(window) window.count++;
     })
 
+    const activeWindow = windows.sort((a,b) => b.count - a.count)[0];
+    return activeWindow;
 
-  } catch (err) {}
+  } catch (err) {
+    console.error('Calculate active window error:', err);
+    return { start: 19, end: 22, count: 0 }; 
+  }
 }

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -75,3 +75,13 @@ async function updateUserActiveWindow(userId) {
     throw err;
   }
 }
+
+async function getUsersActiveWindow(userId) {
+  try {
+    const { data: user, error } = await supabase
+      .from("profiles")
+      .select("active_window_start, active_window_end, last_window_calculated")
+      .eq("id", userId)
+      .single();
+  } catch (err) {}
+}

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -26,27 +26,52 @@ async function calculateActiveWindow(userId) {
     //updating count whenever activity takes place
     //within those windows
     const windows = [
-      { start: 0, end: 3, count: 0 }, 
-      { start: 3, end: 6, count: 0 }, 
-      { start: 6, end: 9, count: 0 }, 
-      { start: 9, end: 12, count: 0 }, 
-      { start: 12, end: 15, count: 0 }, 
-      { start: 15, end: 18, count: 0 }, 
-      { start: 18, end: 21, count: 0 }, 
-      { start: 21, end: 24, count: 0 }, 
+      { start: 0, end: 3, count: 0 },
+      { start: 3, end: 6, count: 0 },
+      { start: 6, end: 9, count: 0 },
+      { start: 9, end: 12, count: 0 },
+      { start: 12, end: 15, count: 0 },
+      { start: 15, end: 18, count: 0 },
+      { start: 18, end: 21, count: 0 },
+      { start: 21, end: 24, count: 0 },
     ];
 
-    activities.forEach(activity => {
+    activities.forEach((activity) => {
       const hour = new Date(activity.created_at).getHours();
-      const window = windows.find(w => hour >= w.start && hour < w.end);
-      if(window) window.count++;
-    })
+      const window = windows.find((w) => hour >= w.start && hour < w.end);
+      if (window) window.count++;
+    });
 
-    const activeWindow = windows.sort((a,b) => b.count - a.count)[0];
+    const activeWindow = windows.sort((a, b) => b.count - a.count)[0];
     return activeWindow;
-
   } catch (err) {
-    console.error('Calculate active window error:', err);
-    return { start: 19, end: 22, count: 0 }; 
+    console.error("Calculate active window error:", err);
+    return { start: 19, end: 22, count: 0 };
+  }
+}
+
+//this function only gets called
+//whenever user window has never been calculated
+//or it has been 7 days so we can always have
+//recent activity not stale old data
+async function updateUserActiveWindow(userId) {
+  try {
+    const window = await calculateActiveWindow(userId);
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({
+        active_window_start: window.start,
+        active_window_end: window.end,
+        last_window_calculated: new Date().toISOString(),
+      })
+      .eq("id", userId);
+
+    if (error) throw error;
+
+    return window;
+  } catch (err) {
+    console.error("Update active window error:", err);
+    throw err;
   }
 }

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -35,5 +35,13 @@ async function calculateActiveWindow(userId) {
       { start: 18, end: 21, count: 0 }, 
       { start: 21, end: 24, count: 0 }, 
     ];
+
+    activities.forEach(activity => {
+      const hour = new Date(activity.created_at).getHours();
+      const window = windows.find(w => hour >= w.start && hour < w.end);
+      if(window) window.count++;
+    })
+
+
   } catch (err) {}
 }

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -78,23 +78,29 @@ async function updateUserActiveWindow(userId) {
 
 async function getUsersActiveWindow(userId) {
   try {
-
     const { data: user, error } = await supabase
       .from("profiles")
       .select("active_window_start, active_window_end, last_window_calculated")
       .eq("id", userId)
       .single();
 
-      if(error) throw error;
+    if (error) throw error;
 
-      const sevenDaysAgo = new Date();
-      sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
+    const sevenDaysAgo = new Date();
+    sevenDaysAgo.setDate(sevenDaysAgo.getDate() - 7);
 
-      const needsUpdate = !user.last_window_calculated || new Date(user.last_window_calculated) < sevenDaysAgo;
+    const needsUpdate =
+      !user.last_window_calculated ||
+      new Date(user.last_window_calculated) < sevenDaysAgo;
 
-      if(needsUpdate)
-        return await updateUserActiveWindow(userId);
+    if (needsUpdate) return await updateUserActiveWindow(userId);
 
-      
-  } catch (err) {}
+    return {
+      start: user.active_window_start,
+      end: user.active_window_end,
+    };
+  } catch (err) {
+    console.error("Get user active window error:", err);
+    return { start: 19, end: 22 };
+  }
 }

--- a/backend/services/activityAnalysis.js
+++ b/backend/services/activityAnalysis.js
@@ -76,6 +76,8 @@ async function updateUserActiveWindow(userId) {
   }
 }
 
+//this function is main entry point that we will check
+//when scheduling notifications
 async function getUsersActiveWindow(userId) {
   try {
     const { data: user, error } = await supabase
@@ -93,7 +95,9 @@ async function getUsersActiveWindow(userId) {
       !user.last_window_calculated ||
       new Date(user.last_window_calculated) < sevenDaysAgo;
 
-    if (needsUpdate) return await updateUserActiveWindow(userId);
+    if (needsUpdate) {
+      return await updateUserActiveWindow(userId);
+    }
 
     return {
       start: user.active_window_start,
@@ -104,3 +108,9 @@ async function getUsersActiveWindow(userId) {
     return { start: 19, end: 22 };
   }
 }
+
+module.exports = {
+  calculateActiveWindow,
+  updateUserActiveWindow,
+  getUsersActiveWindow,
+};

--- a/backend/services/createNotifHelper.js
+++ b/backend/services/createNotifHelper.js
@@ -1,4 +1,5 @@
 const { sendNotificationToUser } = require("../websocket/websocketServer");
+const { getUsersActiveWindow } = require("./activityAnalysis");
 
 //This function is a helper that allows us to make a notif in table after certain triggers
 //we also call the sendNotificationToUser function that attempts to send same notification
@@ -8,6 +9,19 @@ async function createNotification(
   { userId, type, title, message, contextData = {}, priority = "general" }
 ) {
   try {
+    //lets let the status of a notif be delivered by default
+    let status = "delivered";
+
+    if (priority === "general") {
+      const window = await getUsersActiveWindow(userId);
+      const currentHour = new Date().getHours();
+
+      if (currentHour >= window.start && currentHour < window.end) {
+        status = "delivered"; // Send now - user will see it
+      } else {
+        status = "pending"; // Queue for later - user won't see it yet
+      }
+    }
     //gotta get notification back when its created so we can try to notify user if they are online
     const { data: notification, error } = await supabaseClient
       .from("notifications")
@@ -33,7 +47,6 @@ async function createNotification(
         `User ${userId} offline, notification stored in database only`
       );
     }
-    
   } catch (err) {
     console.error("Could not create a notification", err);
     throw err;

--- a/backend/services/createNotifHelper.js
+++ b/backend/services/createNotifHelper.js
@@ -32,19 +32,25 @@ async function createNotification(
         message,
         contextData,
         priority,
+        status,
       })
       .select()
       .single();
 
     if (error) throw error;
 
-    const sent = sendNotificationToUser(userId, notification);
-
-    if (sent) {
-      console.log(`Sent notification via WebSocket to user ${userId}`);
+    if (status === "delivered") {
+      const sent = sendNotificationToUser(userId, notification);
+      if (sent) {
+        console.log(`Sent notification via WebSocket to user ${userId}`);
+      } else {
+        console.log(
+          `User ${userId} offline, notification stored in database only`
+        );
+      }
     } else {
       console.log(
-        `User ${userId} offline, notification stored in database only`
+        `General notification queued for user ${userId} (outside active window)`
       );
     }
   } catch (err) {

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -45,10 +45,33 @@ async function deliverPendingNotifications() {
       }
     }
   } catch (err) {
-    console.error("Error with the background job that gets all users with pending notifications", err)
+    console.error(
+      "Error with the background job that gets all users with pending notifications",
+      err
+    );
   }
 }
 
 //function will change noitfication status from pending to delievered
 //to individual users
-async function deliverUserPendingNotifications(userId) {}
+async function deliverUserPendingNotifications(userId) {
+  try {
+    const { data: pendingNotifications, error: notifError } = await supabase
+      .from("notifications")
+      .select("*")
+      .eq("user_id", userId)
+      .eq("status", "pending");
+
+    if (notifError) {
+      console.error(
+        `Error fetching pending notifications for user`,
+        notifError
+      );
+      return;
+    }
+
+    if (!pendingNotifications || pendingNotifications.length === 0) {
+      return; 
+    }
+  } catch (err) {}
+}

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -24,6 +24,21 @@ async function deliverPendingNotifications() {
       );
       return;
     }
+
+    if(!usersWithPending || usersWithPending.length === 0){
+      return;
+    }
+
+    //remember what I said above user might have multiple notifications pending so put the results
+    //from query in a Set to avoid duplicates and just have userId of users who need notifications updated
+    const uniqueUserIds = [...new Set(usersWithPending.map(n => n.user_id))];
+
+    for()
+
+
+
+
+
   } catch (err) {}
 }
 

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -15,8 +15,7 @@ async function deliverPendingNotifications() {
     const { data: usersWithPending, error: usersError } = await supabase
       .from("notifications")
       .select("user_id")
-      .eq("status", "pending")
-      .neq("user_id", null);
+      .eq("status", "pending");
 
     if (usersError) {
       console.error(

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -81,13 +81,21 @@ async function deliverUserPendingNotifications(userId) {
       .eq("status", "pending");
 
     if (updateError) {
-      console.error(
-        `Error updating notifications for user`,
-        updateError
-      );
+      console.error(`Error updating notifications for user`, updateError);
       return;
     }
 
-    
-  } catch (err) {}
+    //after we update try and send notifications through websocket
+    //function we have will handle that
+    pendingNotifications.forEach((notification) => {
+      const sent = sendNotificationToUser(userId, notification);
+      if (sent) {
+        console.log(
+          `Sent pending notification that is now a delievered one via WebSocket to user`
+        );
+      }
+    });
+  } catch (err) {
+    console.error(`Error delivering notifications to user`, err);
+  }
 }

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -1,0 +1,11 @@
+const { supabase } = require("./supabaseclient");
+const { sendNotificationToUser } = require("../websocket/websocketServer");
+
+//function will check what users fall within
+//active window during a set interval and call a helper function
+//that updates each users notifications
+async function deliverPendingNotifications() {}
+
+//function will change noitfication status from pending to delievered
+//to individual users
+async function deliverUserPendingNotifications(userId) {}

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -71,7 +71,23 @@ async function deliverUserPendingNotifications(userId) {
     }
 
     if (!pendingNotifications || pendingNotifications.length === 0) {
-      return; 
+      return;
     }
+
+    const { error: updateError } = await supabase
+      .from("notifications")
+      .update({ status: "delivered" })
+      .eq("user_id", userId)
+      .eq("status", "pending");
+
+    if (updateError) {
+      console.error(
+        `Error updating notifications for user`,
+        updateError
+      );
+      return;
+    }
+
+    
   } catch (err) {}
 }

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -99,3 +99,15 @@ async function deliverUserPendingNotifications(userId) {
     console.error(`Error delivering notifications to user`, err);
   }
 }
+
+function startGeneralNotificationScheduler() {
+  console.log(`Starting general notification scheduler...`);
+
+  //run function as soon as app starts
+  deliverPendingNotifications();
+
+  //then run it once every hour
+  setInterval(deliverPendingNotifications, 60 * 60 * 1000);
+}
+
+module.exports = { startGeneralNotificationScheduler };

--- a/backend/services/notificationScheduler.js
+++ b/backend/services/notificationScheduler.js
@@ -4,7 +4,28 @@ const { sendNotificationToUser } = require("../websocket/websocketServer");
 //function will check what users fall within
 //active window during a set interval and call a helper function
 //that updates each users notifications
-async function deliverPendingNotifications() {}
+async function deliverPendingNotifications() {
+  try {
+    const currentHour = new Date().getHours();
+
+    //we need to get all users who have pending notifs
+    //keep in mind this might return duplicate userIds since one user
+    //might have multiple pending notifications
+    const { data: usersWithPending, error: usersError } = await supabase
+      .from("notifications")
+      .select("user_id")
+      .eq("status", "pending")
+      .neq("user_id", null);
+
+    if (usersError) {
+      console.error(
+        "Error fetching users with pending notifications:",
+        usersError
+      );
+      return;
+    }
+  } catch (err) {}
+}
 
 //function will change noitfication status from pending to delievered
 //to individual users

--- a/backend/websocket/websocketServer.js
+++ b/backend/websocket/websocketServer.js
@@ -9,18 +9,21 @@ const clients = new Map();
 
 //this function will get called by createNotification helper whenever notification gets created
 //it attempts to send real time notification if user is online (they are on clients map)
-function sendNotificationToUser(userId, notification) {
+async function sendNotificationToUser(userId, notification) {
   const userConnection = clients.get(userId);
 
   //we check map above if the userId is there websocket object is returned so check if
   //it is exists (isnt null) and the readyState of the ws object is OPEN
   if (userConnection && userConnection.readyState === WebSocket.OPEN) {
-    userConnection.send(
-      JSON.stringify({
-        type: "notification",
-        data: notification,
-      })
-    );
+    const shouldSend = await shouldSendNotificationToUser(userId, notification);
+    if (shouldSend) {
+      userConnection.send(
+        JSON.stringify({
+          type: "notification",
+          data: notification,
+        })
+      );
+    }
 
     console.log(`Sent notif to user ${userId}`);
     return true;

--- a/backend/websocket/websocketServer.js
+++ b/backend/websocket/websocketServer.js
@@ -1,6 +1,8 @@
 const WebSocket = require("ws");
 const { supbase, supabase } = require("../services/supabaseclient");
 
+//*** TODO: REMEMBER TO REMOVE CONSOLE LOGS FOR PROD ***/
+
 //this map is going allow us to store each user when they come online along with their ws object (connection)
 // clients = userId: WebSocket connection
 const clients = new Map();

--- a/backend/websocket/websocketServer.js
+++ b/backend/websocket/websocketServer.js
@@ -29,7 +29,7 @@ async function sendNotificationToUser(userId, notification) {
     return true;
   }
 
-  console.log(`user is not connected did not send notif real time`);
+  console.log(`user is not connected or notif was disabled did not send notif real time`);
   return false;
 }
 

--- a/frontend/src/Context/AuthProvider.tsx
+++ b/frontend/src/Context/AuthProvider.tsx
@@ -46,7 +46,7 @@ export function AuthProvider({ children }: any) {
           const settings = await getNotificationSettings(session.access_token);
           setNotificationSettings(settings);
         } catch (error) {
-          console.error("Failed to load notification settings:", error);
+          setNotificationSettings(null);
         }
       }
     }
@@ -56,8 +56,12 @@ export function AuthProvider({ children }: any) {
       setSession(session);
       setUser(session?.user || null);
       if (session?.access_token) {
-        const settings = await getNotificationSettings(session.access_token);
-        setNotificationSettings(settings);
+        try {
+          const settings = await getNotificationSettings(session.access_token);
+          setNotificationSettings(settings);
+        } catch (error) {
+          setNotificationSettings(null);
+        }
       }
       setLoading(false);
     });

--- a/frontend/src/Context/AuthProvider.tsx
+++ b/frontend/src/Context/AuthProvider.tsx
@@ -39,7 +39,6 @@ export function AuthProvider({ children }: any) {
       if (error) throw error;
       setSession(session);
       setUser(session?.user || null);
-      setLoading(false); //dont forget to set loading to false afterwards
 
       if (session?.access_token) {
         try {
@@ -49,6 +48,8 @@ export function AuthProvider({ children }: any) {
           setNotificationSettings(null);
         }
       }
+
+      setLoading(false); //dont forget to set loading to false afterwards
     }
 
     //this onAuthStateChange is a supabase provided function that listens to whenever user signs in, signs out, token refreshes, etc. As soon as any of this happens event is fired and all context state is updated accordingly

--- a/frontend/src/Context/AuthProvider.tsx
+++ b/frontend/src/Context/AuthProvider.tsx
@@ -1,19 +1,24 @@
 import type { Session, User } from "@supabase/supabase-js";
 import { useContext, useState, useEffect, createContext } from "react";
 import { supabase } from "@/lib/supabaseclient";
+import { getNotificationSettings } from "@/lib/api_client";
 
 //context type
 type AuthContextType = {
   session: Session | null;
   user: User | null;
   loading: boolean;
+  notificationSettings: any | null;
+  setNotificationSettings: (settings: any) => void;
   signOut: () => void;
 };
-//creating the context with default values for the session, user, and signOut method
+//creating the context with default values for the session, user, notif sttings, and udater and signOut method
 const AuthContext = createContext<AuthContextType>({
   session: null,
   user: null,
   loading: true,
+  notificationSettings: null,
+  setNotificationSettings: () => {},
   signOut: () => {},
 });
 
@@ -21,6 +26,7 @@ export function AuthProvider({ children }: any) {
   const [user, setUser] = useState<User | null>(null);
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true); //true by default cause its loading until info is loaded
+  const [notificationSettings, setNotificationSettings] = useState<any | null>(null);
 
   //on page mount we want to check the users auth status
   useEffect(() => {
@@ -34,12 +40,25 @@ export function AuthProvider({ children }: any) {
       setSession(session);
       setUser(session?.user || null);
       setLoading(false); //dont forget to set loading to false afterwards
+
+      if (session?.access_token) {
+        try {
+          const settings = await getNotificationSettings(session.access_token);
+          setNotificationSettings(settings);
+        } catch (error) {
+          console.error("Failed to load notification settings:", error);
+        }
+      }
     }
 
     //this onAuthStateChange is a supabase provided function that listens to whenever user signs in, signs out, token refreshes, etc. As soon as any of this happens event is fired and all context state is updated accordingly
-    const { data: listener } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: listener } = supabase.auth.onAuthStateChange(async (_event, session) => {
       setSession(session);
       setUser(session?.user || null);
+      if (session?.access_token) {
+        const settings = await getNotificationSettings(session.access_token);
+        setNotificationSettings(settings);
+      }
       setLoading(false);
     });
 
@@ -56,6 +75,8 @@ export function AuthProvider({ children }: any) {
     session,
     user,
     loading,
+    notificationSettings,
+    setNotificationSettings,
     signOut: async () => {
       await supabase.auth.signOut();
     }, //supabase signout function just store in our signOut for better readability. Other components can acess everywhere

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -12,6 +12,7 @@ export default function NotificationList() {
   const { session } = useAuthContext();
   const { newNotification } = useWebSocketContext(); //this grabs the newNotification if there is one after server sent user message
   const [notifications, setNotifications] = useState<Notification[]>([]);
+  const { notificationSettings } = useAuthContext();
 
   //function gets called whenever an action on notification is clicked.
   //Whether it be an accept or deny or read and handles it
@@ -44,6 +45,39 @@ export default function NotificationList() {
         console.error("Could not mark notification as read", err);
       }
     }
+  }
+
+  //function to apply settings to notifications we get from context. Only show notifications user has toggled on
+  function filterNotifications(notifications: Notification[]) {
+    if (!notificationSettings) return notifications;
+
+    return notifications.filter(notification => {
+      if (notification.priority === "immediate" && !notificationSettings.important_enabled) {
+        return false;
+      }
+
+      if (notification.priority === "general" && !notificationSettings.general_enabled) {
+        return false;
+      }
+      switch (notification.type) {
+        case "connection_request":
+          return notificationSettings.connection_request_enabled;
+        case "connection_accepted":
+          return notificationSettings.connection_accepted_enabled;
+        case "connection_denied":
+          return notificationSettings.connection_denied_enabled;
+        case "private_event_invitation":
+          return notificationSettings.private_event_invitation_enabled;
+        case "event_rsvp_updates":
+          return notificationSettings.event_rsvp_updates_enabled;
+        case "public_event_announcements":
+          return notificationSettings.public_event_announcements_enabled;
+        case "network_event_announcements":
+          return notificationSettings.network_event_announcements_enabled;
+        default:
+          return true;
+      }
+    });
   }
 
   useEffect(() => {

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -70,7 +70,7 @@ export default function NotificationList() {
           return notificationSettings.private_event_invitation_enabled;
         case "event_rsvp_updates":
           return notificationSettings.event_rsvp_updates_enabled;
-        case "public_event_announcements":
+        case "public_event_announcement":
           return notificationSettings.public_event_announcements_enabled;
         case "network_event_announcements":
           return notificationSettings.network_event_announcements_enabled;

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -101,8 +101,9 @@ export default function NotificationList() {
   }, [newNotification]);
 
   //for now we want to separate the notifications whose priortiy is immediate vs the ones who have a general priortiy
-  const immediateNotifications = notifications.filter(n => n.priority === "immediate");
-  const generalNotifications = notifications.filter(n => n.priority === "general");
+  const notificationsPostSettings = filterNotifications(notifications);
+  const immediateNotifications = notificationsPostSettings.filter(n => n.priority === "immediate");
+  const generalNotifications = notificationsPostSettings.filter(n => n.priority === "general");
 
   return (
     <div className='flex flex-col gap-6'>

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -50,39 +50,6 @@ export default function NotificationList() {
     }
   }
 
-  //function to apply settings to notifications we get from context. Only show notifications user has toggled on
-  // function filterNotifications(notifications: Notification[]) {
-  //   if (!notificationSettings) return notifications;
-
-  //   return notifications.filter(notification => {
-  //     if (notification.priority === "immediate" && !notificationSettings.important_enabled) {
-  //       return false;
-  //     }
-
-  //     if (notification.priority === "general" && !notificationSettings.general_enabled) {
-  //       return false;
-  //     }
-  //     switch (notification.type) {
-  //       case "connection_request":
-  //         return notificationSettings.connection_request_enabled;
-  //       case "connection_accepted":
-  //         return notificationSettings.connection_accepted_enabled;
-  //       case "connection_denied":
-  //         return notificationSettings.connection_denied_enabled;
-  //       case "private_event_invitation":
-  //         return notificationSettings.private_event_invitation_enabled;
-  //       case "event_rsvp_updates":
-  //         return notificationSettings.event_rsvp_updates_enabled;
-  //       case "public_event_announcement":
-  //         return notificationSettings.public_event_announcements_enabled;
-  //       case "network_event_announcements":
-  //         return notificationSettings.network_event_announcements_enabled;
-  //       default:
-  //         return true;
-  //     }
-  //   });
-  // }
-
   useEffect(() => {
     async function getNotifications() {
       if (!session?.access_token) return;
@@ -117,8 +84,6 @@ export default function NotificationList() {
     }
   }, [newNotification]);
 
-  // //for now we want to separate the notifications whose priortiy is immediate vs the ones who have a general priortiy
-  // const notificationsPostSettings = filterNotifications(notifications);
   const immediateNotifications = notifications.filter(n => n.priority === "immediate");
   const generalNotifications = notifications.filter(n => n.priority === "general");
 

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -13,7 +13,6 @@ export default function NotificationList() {
   const { session } = useAuthContext();
   const { newNotification } = useWebSocketContext(); //this grabs the newNotification if there is one after server sent user message
   const [notifications, setNotifications] = useState<Notification[]>([]);
-  const { notificationSettings } = useAuthContext();
 
   //function gets called whenever an action on notification is clicked.
   //Whether it be an accept or deny or read and handles it

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -41,7 +41,7 @@ export default function NotificationList() {
       try {
         if (!session?.access_token) return;
 
-        await updateNotificationStatus(session.access_token, notification.id, "read");
+        updateNotificationStatus(session.access_token, notification.id, "read");
         setNotifications(prev => prev.filter(n => n.id !== notification.id));
         postActivity(session.access_token, "notification_action");
       } catch (err) {
@@ -51,37 +51,37 @@ export default function NotificationList() {
   }
 
   //function to apply settings to notifications we get from context. Only show notifications user has toggled on
-  function filterNotifications(notifications: Notification[]) {
-    if (!notificationSettings) return notifications;
+  // function filterNotifications(notifications: Notification[]) {
+  //   if (!notificationSettings) return notifications;
 
-    return notifications.filter(notification => {
-      if (notification.priority === "immediate" && !notificationSettings.important_enabled) {
-        return false;
-      }
+  //   return notifications.filter(notification => {
+  //     if (notification.priority === "immediate" && !notificationSettings.important_enabled) {
+  //       return false;
+  //     }
 
-      if (notification.priority === "general" && !notificationSettings.general_enabled) {
-        return false;
-      }
-      switch (notification.type) {
-        case "connection_request":
-          return notificationSettings.connection_request_enabled;
-        case "connection_accepted":
-          return notificationSettings.connection_accepted_enabled;
-        case "connection_denied":
-          return notificationSettings.connection_denied_enabled;
-        case "private_event_invitation":
-          return notificationSettings.private_event_invitation_enabled;
-        case "event_rsvp_updates":
-          return notificationSettings.event_rsvp_updates_enabled;
-        case "public_event_announcement":
-          return notificationSettings.public_event_announcements_enabled;
-        case "network_event_announcements":
-          return notificationSettings.network_event_announcements_enabled;
-        default:
-          return true;
-      }
-    });
-  }
+  //     if (notification.priority === "general" && !notificationSettings.general_enabled) {
+  //       return false;
+  //     }
+  //     switch (notification.type) {
+  //       case "connection_request":
+  //         return notificationSettings.connection_request_enabled;
+  //       case "connection_accepted":
+  //         return notificationSettings.connection_accepted_enabled;
+  //       case "connection_denied":
+  //         return notificationSettings.connection_denied_enabled;
+  //       case "private_event_invitation":
+  //         return notificationSettings.private_event_invitation_enabled;
+  //       case "event_rsvp_updates":
+  //         return notificationSettings.event_rsvp_updates_enabled;
+  //       case "public_event_announcement":
+  //         return notificationSettings.public_event_announcements_enabled;
+  //       case "network_event_announcements":
+  //         return notificationSettings.network_event_announcements_enabled;
+  //       default:
+  //         return true;
+  //     }
+  //   });
+  // }
 
   useEffect(() => {
     async function getNotifications() {
@@ -100,21 +100,33 @@ export default function NotificationList() {
   }, [session?.access_token]);
 
   useEffect(() => {
+    if (!session?.access_token) {
+      throw Error("no valid session");
+    }
     if (newNotification) {
       setNotifications(prev => [newNotification, ...prev]);
     }
+
+    //when new notification comes in if its the actionable ones we want to send nudges for 
+    //mark them as seen since they came in live through websocket user is online and saw them.
+    if (
+      newNotification?.type === "connection_request" ||
+      newNotification?.type === "private_event_invitation"
+    ) {
+      updateNotificationStatus(session.access_token, newNotification.id, "seen");
+    }
   }, [newNotification]);
 
-  //for now we want to separate the notifications whose priortiy is immediate vs the ones who have a general priortiy
-  const notificationsPostSettings = filterNotifications(notifications);
-  const immediateNotifications = notificationsPostSettings.filter(n => n.priority === "immediate");
-  const generalNotifications = notificationsPostSettings.filter(n => n.priority === "general");
+  // //for now we want to separate the notifications whose priortiy is immediate vs the ones who have a general priortiy
+  // const notificationsPostSettings = filterNotifications(notifications);
+  const immediateNotifications = notifications.filter(n => n.priority === "immediate");
+  const generalNotifications = notifications.filter(n => n.priority === "general");
 
   return (
     <div className='flex flex-col gap-6'>
       <div>
         <h3 className='mb-3 text-lg font-semibold text-red-600'>🚨 Important</h3>
-        <div className='flex flex-col gap-3 max-h-50 overflow-y-auto'>
+        <div className='flex max-h-50 flex-col gap-3 overflow-y-auto'>
           {immediateNotifications.length > 0 ? (
             immediateNotifications.map(notification => (
               <NotificationItem
@@ -131,7 +143,7 @@ export default function NotificationList() {
 
       <div>
         <h3 className='mb-3 text-lg font-semibold text-gray-700'>📬 General</h3>
-        <div className='flex flex-col gap-3 max-h-50 overflow-y-auto'>
+        <div className='flex max-h-50 flex-col gap-3 overflow-y-auto'>
           {generalNotifications.length > 0 ? (
             generalNotifications.map(notification => (
               <NotificationItem

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -114,7 +114,7 @@ export default function NotificationList() {
     <div className='flex flex-col gap-6'>
       <div>
         <h3 className='mb-3 text-lg font-semibold text-red-600'>🚨 Important</h3>
-        <div className='flex flex-col gap-3'>
+        <div className='flex flex-col gap-3 max-h-50 overflow-y-auto'>
           {immediateNotifications.length > 0 ? (
             immediateNotifications.map(notification => (
               <NotificationItem
@@ -131,7 +131,7 @@ export default function NotificationList() {
 
       <div>
         <h3 className='mb-3 text-lg font-semibold text-gray-700'>📬 General</h3>
-        <div className='flex flex-col gap-3'>
+        <div className='flex flex-col gap-3 max-h-50 overflow-y-auto'>
           {generalNotifications.length > 0 ? (
             generalNotifications.map(notification => (
               <NotificationItem

--- a/frontend/src/components/NotificationList/NotificationList.tsx
+++ b/frontend/src/components/NotificationList/NotificationList.tsx
@@ -6,6 +6,7 @@ import { fetchNotifications } from "@/lib/api_client";
 import { setConnectionRequestStatusAndPostIfAccept } from "@/lib/api_client";
 import { updateNotificationStatus } from "@/lib/api_client";
 import { useWebSocketContext } from "@/Context/WebSocketProvider";
+import { postActivity } from "@/lib/api_client";
 import type { Notification } from "@/types/AppTypes";
 
 export default function NotificationList() {
@@ -31,6 +32,7 @@ export default function NotificationList() {
 
         if (res.success) {
           setNotifications(prev => prev.filter(n => n.id !== notification.id));
+          postActivity(session.access_token, "notification_action");
         }
       } catch (err) {
         console.error("Could not process connection request", err);
@@ -41,6 +43,7 @@ export default function NotificationList() {
 
         await updateNotificationStatus(session.access_token, notification.id, "read");
         setNotifications(prev => prev.filter(n => n.id !== notification.id));
+        postActivity(session.access_token, "notification_action");
       } catch (err) {
         console.error("Could not mark notification as read", err);
       }
@@ -86,6 +89,8 @@ export default function NotificationList() {
       try {
         const notifications = await fetchNotifications(session.access_token);
         setNotifications(notifications);
+
+        postActivity(session.access_token, "notification_view");
       } catch (err) {
         console.error("Failed to get notifs", err);
       }

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -42,7 +42,7 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
     if (!session?.access_token) return;
 
     try {
-      await updateNotificationSettings(session.access_token, {
+      setNotificationSettings({
         push_enabled: pushEnabled,
         important_enabled: importantEnabled,
         general_enabled: generalEnabled,
@@ -54,8 +54,8 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
         public_event_announcements_enabled: publicEventAnnouncementsEnabled,
         network_event_announcements_enabled: networkEventAnnouncementsEnabled,
       });
-
-      setNotificationSettings({
+      
+      await updateNotificationSettings(session.access_token, {
         push_enabled: pushEnabled,
         important_enabled: importantEnabled,
         general_enabled: generalEnabled,

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -37,6 +37,28 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
 
   const [loading, setLoading] = useState(true);
 
+  async function handleSave() {
+    if (!session?.access_token) return;
+
+    try {
+      await updateNotificationSettings(session.access_token, {
+        push_enabled: pushEnabled,
+        important_enabled: importantEnabled,
+        general_enabled: generalEnabled,
+        connection_request_enabled: connectRequestEnabled,
+        connection_accepted_enabled: connectionAcceptedEnabled,
+        connection_denied_enabled: connectionDeniedEnabled,
+        private_event_invitation_enabled: privateEventInvitationEnabled,
+        event_rsvp_updates_enabled: eventRsvpUpdatesEnabled,
+        public_event_announcements_enabled: publicEventAnnouncementsEnabled,
+        network_event_announcements_enabled: networkEventAnnouncementsEnabled,
+      });
+      onClose();
+    } catch (error) {
+      console.error("Failed to save settings:", error);
+    }
+  }
+
   useEffect(() => {
     async function loadSettings() {
       if (!session?.access_token) return;
@@ -229,7 +251,10 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
       </main>
 
       <footer className='flex flex-shrink-0 justify-center rounded-b-lg border-t border-white bg-gray-100 px-6 py-4'>
-        <button className='bg-twitch-purple w-3/4 cursor-pointer rounded-lg px-4 py-2 font-medium text-white'>
+        <button
+          onClick={handleSave}
+          className='bg-twitch-purple w-3/4 cursor-pointer rounded-lg px-4 py-2 font-medium text-white'
+        >
           {loading ? "Loading..." : "Save Settings"}
         </button>
       </footer>

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -177,7 +177,7 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
         </div>
       </main>
 
-      <footer className='flex flex-shrink-0 justify-center border-t border-white bg-gray-100 px-6 py-4 rounded-b-lg'>
+      <footer className='flex flex-shrink-0 justify-center rounded-b-lg border-t border-white bg-gray-100 px-6 py-4'>
         <button className='bg-twitch-purple w-3/4 cursor-pointer rounded-lg px-4 py-2 font-medium text-white'>
           Save Settings
         </button>

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -267,7 +267,7 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
       <footer className='flex flex-shrink-0 justify-center rounded-b-lg border-t border-white bg-gray-100 px-6 py-4'>
         <button
           onClick={handleSave}
-          className='bg-twitch-purple w-3/4 cursor-pointer rounded-lg px-4 py-2 font-medium text-white'
+          className='bg-twitch-purple w-3/4 cursor-pointer rounded-lg px-4 py-2 font-medium text-white hover:bg-purple-800 transition-colors duration-200'
         >
           {loading ? "Loading..." : "Save Settings"}
         </button>

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -1,11 +1,15 @@
 import { X } from "lucide-react";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useAuthContext } from "@/Context/AuthProvider";
+import { updateNotificationSettings } from "@/lib/api_client";
+import { getNotificationSettings } from "@/lib/api_client";
 
 type NotificationSettingsModalProps = {
   onClose: () => void;
 };
 
 export default function NotificationSettingsModal({ onClose }: NotificationSettingsModalProps) {
+  const { session } = useAuthContext();
   const [pushEnabled, setPushEnabled] = useState(true);
   const [importantEnabled, setImportantEnabled] = useState(true);
   const [generalEnabled, setGeneralEnabled] = useState(true);
@@ -17,6 +21,14 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
   const [publicEventAnnouncementsEnabled, setPublicEventAnnouncementsEnabled] = useState(true);
   const [networkEventAnnouncementsEnabled, setNetworkEventAnnouncementsEnabled] = useState(true);
 
+  useEffect(() => {
+    async function loadSettings() {
+      if (!session?.access_token) return;
+      const settings = await getNotificationSettings(session?.access_token);
+    }
+
+    loadSettings();
+  }, [session?.access_token]);
   return (
     <section className='flex max-h-[70vh] w-full max-w-xl flex-col rounded-lg bg-white'>
       {/*Header just has title and close  */}

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -10,21 +10,53 @@ type NotificationSettingsModalProps = {
 
 export default function NotificationSettingsModal({ onClose }: NotificationSettingsModalProps) {
   const { session } = useAuthContext();
-  const [pushEnabled, setPushEnabled] = useState(true);
-  const [importantEnabled, setImportantEnabled] = useState(true);
-  const [generalEnabled, setGeneralEnabled] = useState(true);
-  const [connectRequestEnabled, setConnectRequestEnabled] = useState(true);
-  const [connectionAcceptedEnabled, setConnectionAcceptedEnabled] = useState(true);
-  const [connectionDeniedEnabled, setConnectionDeniedEnabled] = useState(true);
-  const [privateEventInvitationEnabled, setPrivateEventInvitationEnabled] = useState(true);
-  const [eventRsvpUpdatesEnabled, setEventRsvpUpdatesEnabled] = useState(true);
-  const [publicEventAnnouncementsEnabled, setPublicEventAnnouncementsEnabled] = useState(true);
-  const [networkEventAnnouncementsEnabled, setNetworkEventAnnouncementsEnabled] = useState(true);
+  const [pushEnabled, setPushEnabled] = useState<boolean | undefined>(undefined);
+  const [importantEnabled, setImportantEnabled] = useState<boolean | undefined>(undefined);
+  const [generalEnabled, setGeneralEnabled] = useState<boolean | undefined>(undefined);
+  const [connectRequestEnabled, setConnectRequestEnabled] = useState<boolean | undefined>(
+    undefined,
+  );
+  const [connectionAcceptedEnabled, setConnectionAcceptedEnabled] = useState<boolean | undefined>(
+    undefined,
+  );
+  const [connectionDeniedEnabled, setConnectionDeniedEnabled] = useState<boolean | undefined>(
+    undefined,
+  );
+  const [privateEventInvitationEnabled, setPrivateEventInvitationEnabled] = useState<
+    boolean | undefined
+  >(undefined);
+  const [eventRsvpUpdatesEnabled, setEventRsvpUpdatesEnabled] = useState<boolean | undefined>(
+    undefined,
+  );
+  const [publicEventAnnouncementsEnabled, setPublicEventAnnouncementsEnabled] = useState<
+    boolean | undefined
+  >(undefined);
+  const [networkEventAnnouncementsEnabled, setNetworkEventAnnouncementsEnabled] = useState<
+    boolean | undefined
+  >(undefined);
+
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     async function loadSettings() {
       if (!session?.access_token) return;
-      const settings = await getNotificationSettings(session?.access_token);
+      try {
+        const settings = await getNotificationSettings(session?.access_token);
+        setPushEnabled(settings.push_enabled);
+        setImportantEnabled(settings.important_enabled);
+        setGeneralEnabled(settings.general_enabled);
+        setConnectRequestEnabled(settings.connection_request_enabled);
+        setConnectionAcceptedEnabled(settings.connection_accepted_enabled);
+        setConnectionDeniedEnabled(settings.connection_denied_enabled);
+        setPrivateEventInvitationEnabled(settings.private_event_invitation_enabled);
+        setEventRsvpUpdatesEnabled(settings.event_rsvp_updates_enabled);
+        setPublicEventAnnouncementsEnabled(settings.public_event_announcements_enabled);
+        setNetworkEventAnnouncementsEnabled(settings.network_event_announcements_enabled);
+      } catch (err) {
+        console.error("Failed to load notification settings:", err);
+      } finally {
+        setLoading(false);
+      }
     }
 
     loadSettings();

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -75,155 +75,162 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
       {/*Main section comprises all the notification toggles */}
       <main className='flex-1 overflow-y-scroll px-8'>
         {/*This is the Push Notifications toggle has its own little section */}
-        <div className='flex flex-col gap-2 border-b py-5'>
-          <div className='flex items-center justify-between'>
-            <span className='font-medium'> Push Notifications</span>
-            <Toggle enabled={pushEnabled} onToggle={() => setPushEnabled(!pushEnabled)} />
-          </div>
-          <p className='text-sm font-medium text-gray-500'>
-            Receive in-app banner notifications for important priority alerts only
-          </p>
-        </div>
 
-        {/*This section is for important notifications starts with toggle to disbale all or enable and you can select which ones */}
-        <div className='flex flex-col gap-6 border-b py-5'>
-          <div className='flex items-center justify-between'>
-            <span className='font-medium'> 🚨 Important Notifications</span>
-            <Toggle
-              enabled={importantEnabled}
-              onToggle={() => {
-                const newValue = !importantEnabled;
-                setImportantEnabled(newValue);
-                if (!newValue) {
-                  {
-                    /*if turning off important notifs turn off all children as well */
-                  }
-                  setConnectRequestEnabled(false);
-                  setConnectionAcceptedEnabled(false);
-                  setConnectionDeniedEnabled(false);
-                  setPrivateEventInvitationEnabled(false);
-                }
-              }}
-            />
+        {loading ? (
+          <div className='flex items-center justify-center py-16'>
+            <div className='text-gray-500'>Loading settings...</div>
           </div>
+        ) : (
+          <>
+            <div className='flex flex-col gap-2 border-b py-5'>
+              <div className='flex items-center justify-between'>
+                <span className='font-medium'> Push Notifications</span>
+                <Toggle enabled={pushEnabled} onToggle={() => setPushEnabled(!pushEnabled)} />
+              </div>
+              <p className='text-sm font-medium text-gray-500'>
+                Receive in-app banner notifications for important priority alerts only
+              </p>
+            </div>
 
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
-                Connection Request Received
-              </span>
-              <Toggle
-                enabled={connectRequestEnabled}
-                onToggle={() => setConnectRequestEnabled(!connectRequestEnabled)}
-                disabled={!importantEnabled}
-              />
-            </div>
-          </div>
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
-                Connection Request Accepted
-              </span>
-              <Toggle
-                enabled={connectionAcceptedEnabled}
-                onToggle={() => setConnectionAcceptedEnabled(!connectionAcceptedEnabled)}
-                disabled={!importantEnabled}
-              />
-            </div>
-          </div>
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
-                Connection Request Denied
-              </span>
-              <Toggle
-                enabled={connectionDeniedEnabled}
-                onToggle={() => setConnectionDeniedEnabled(!connectionDeniedEnabled)}
-                disabled={!importantEnabled}
-              />
-            </div>
-          </div>
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
-                Private Event Invitation
-              </span>
-              <Toggle
-                enabled={privateEventInvitationEnabled}
-                onToggle={() => setPrivateEventInvitationEnabled(!privateEventInvitationEnabled)}
-                disabled={!importantEnabled}
-              />
-            </div>
-          </div>
-        </div>
+            <div className='flex flex-col gap-6 border-b py-5'>
+              <div className='flex items-center justify-between'>
+                <span className='font-medium'> 🚨 Important Notifications</span>
+                <Toggle
+                  enabled={importantEnabled}
+                  onToggle={() => {
+                    const newValue = !importantEnabled;
+                    setImportantEnabled(newValue);
+                    if (!newValue) {
+                      setConnectRequestEnabled(false);
+                      setConnectionAcceptedEnabled(false);
+                      setConnectionDeniedEnabled(false);
+                      setPrivateEventInvitationEnabled(false);
+                    }
+                  }}
+                />
+              </div>
 
-        {/*Another section but this one is for general notifications same concept as important notifications */}
-        <div className='flex flex-col gap-6 border-b py-5'>
-          <div className='flex items-center justify-between'>
-            <span className='font-medium'> ✉️ General Notifications</span>
-            <Toggle
-              enabled={generalEnabled}
-              onToggle={() => {
-                const newValue = !generalEnabled;
-                setGeneralEnabled(newValue);
-                if (!newValue) {
-                  {
-                    /*if turning off important notifs turn off all children as well */
-                  }
-                  setEventRsvpUpdatesEnabled(false);
-                  setPublicEventAnnouncementsEnabled(false);
-                  setNetworkEventAnnouncementsEnabled(false);
-                }
-              }}
-            />
-          </div>
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
+                    Connection Request Received
+                  </span>
+                  <Toggle
+                    enabled={connectRequestEnabled}
+                    onToggle={() => setConnectRequestEnabled(!connectRequestEnabled)}
+                    disabled={!importantEnabled}
+                  />
+                </div>
+              </div>
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
+                    Connection Request Accepted
+                  </span>
+                  <Toggle
+                    enabled={connectionAcceptedEnabled}
+                    onToggle={() => setConnectionAcceptedEnabled(!connectionAcceptedEnabled)}
+                    disabled={!importantEnabled}
+                  />
+                </div>
+              </div>
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
+                    Connection Request Denied
+                  </span>
+                  <Toggle
+                    enabled={connectionDeniedEnabled}
+                    onToggle={() => setConnectionDeniedEnabled(!connectionDeniedEnabled)}
+                    disabled={!importantEnabled}
+                  />
+                </div>
+              </div>
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!importantEnabled ? "text-gray-500" : "text-black"}>
+                    Private Event Invitation
+                  </span>
+                  <Toggle
+                    enabled={privateEventInvitationEnabled}
+                    onToggle={() =>
+                      setPrivateEventInvitationEnabled(!privateEventInvitationEnabled)
+                    }
+                    disabled={!importantEnabled}
+                  />
+                </div>
+              </div>
+            </div>
 
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!generalEnabled ? "text-gray-500" : "text-black"}>
-                Event RSVP Updates
-              </span>
-              <Toggle
-                enabled={eventRsvpUpdatesEnabled}
-                onToggle={() => setEventRsvpUpdatesEnabled(!eventRsvpUpdatesEnabled)}
-                disabled={!generalEnabled}
-              />
+            {/*Another section but this one is for general notifications same concept as important notifications */}
+            <div className='flex flex-col gap-6 border-b py-5'>
+              <div className='flex items-center justify-between'>
+                <span className='font-medium'> ✉️ General Notifications</span>
+                <Toggle
+                  enabled={generalEnabled}
+                  onToggle={() => {
+                    const newValue = !generalEnabled;
+                    setGeneralEnabled(newValue);
+                    if (!newValue) {
+                      {
+                        /*if turning off important notifs turn off all children as well */
+                      }
+                      setEventRsvpUpdatesEnabled(false);
+                      setPublicEventAnnouncementsEnabled(false);
+                      setNetworkEventAnnouncementsEnabled(false);
+                    }
+                  }}
+                />
+              </div>
+
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!generalEnabled ? "text-gray-500" : "text-black"}>
+                    Event RSVP Updates
+                  </span>
+                  <Toggle
+                    enabled={eventRsvpUpdatesEnabled}
+                    onToggle={() => setEventRsvpUpdatesEnabled(!eventRsvpUpdatesEnabled)}
+                    disabled={!generalEnabled}
+                  />
+                </div>
+              </div>
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!generalEnabled ? "text-gray-500" : "text-black"}>
+                    Public Event Announcements
+                  </span>
+                  <Toggle
+                    enabled={publicEventAnnouncementsEnabled}
+                    onToggle={() =>
+                      setPublicEventAnnouncementsEnabled(!publicEventAnnouncementsEnabled)
+                    }
+                    disabled={!generalEnabled}
+                  />
+                </div>
+              </div>
+              <div className='pl-6'>
+                <div className='flex items-center justify-between'>
+                  <span className={!generalEnabled ? "text-gray-500" : "text-black"}>
+                    Network Event Announcements
+                  </span>
+                  <Toggle
+                    enabled={networkEventAnnouncementsEnabled}
+                    onToggle={() =>
+                      setNetworkEventAnnouncementsEnabled(!networkEventAnnouncementsEnabled)
+                    }
+                    disabled={!generalEnabled}
+                  />
+                </div>
+              </div>
             </div>
-          </div>
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!generalEnabled ? "text-gray-500" : "text-black"}>
-                Public Event Announcements
-              </span>
-              <Toggle
-                enabled={publicEventAnnouncementsEnabled}
-                onToggle={() =>
-                  setPublicEventAnnouncementsEnabled(!publicEventAnnouncementsEnabled)
-                }
-                disabled={!generalEnabled}
-              />
-            </div>
-          </div>
-          <div className='pl-6'>
-            <div className='flex items-center justify-between'>
-              <span className={!generalEnabled ? "text-gray-500" : "text-black"}>
-                Network Event Announcements
-              </span>
-              <Toggle
-                enabled={networkEventAnnouncementsEnabled}
-                onToggle={() =>
-                  setNetworkEventAnnouncementsEnabled(!networkEventAnnouncementsEnabled)
-                }
-                disabled={!generalEnabled}
-              />
-            </div>
-          </div>
-        </div>
+          </>
+        )}
       </main>
 
       <footer className='flex flex-shrink-0 justify-center rounded-b-lg border-t border-white bg-gray-100 px-6 py-4'>
         <button className='bg-twitch-purple w-3/4 cursor-pointer rounded-lg px-4 py-2 font-medium text-white'>
-          Save Settings
+          {loading ? "Loading..." : "Save Settings"}
         </button>
       </footer>
     </section>
@@ -231,7 +238,7 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
 }
 
 type ToggleProps = {
-  enabled: boolean;
+  enabled: boolean | undefined;
   onToggle: () => void;
   disabled?: boolean;
 };

--- a/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
+++ b/frontend/src/components/NotificationSettingsModal/NotifcationSettingsModal.tsx
@@ -10,6 +10,7 @@ type NotificationSettingsModalProps = {
 
 export default function NotificationSettingsModal({ onClose }: NotificationSettingsModalProps) {
   const { session } = useAuthContext();
+  const { setNotificationSettings } = useAuthContext();
   const [pushEnabled, setPushEnabled] = useState<boolean | undefined>(undefined);
   const [importantEnabled, setImportantEnabled] = useState<boolean | undefined>(undefined);
   const [generalEnabled, setGeneralEnabled] = useState<boolean | undefined>(undefined);
@@ -42,6 +43,19 @@ export default function NotificationSettingsModal({ onClose }: NotificationSetti
 
     try {
       await updateNotificationSettings(session.access_token, {
+        push_enabled: pushEnabled,
+        important_enabled: importantEnabled,
+        general_enabled: generalEnabled,
+        connection_request_enabled: connectRequestEnabled,
+        connection_accepted_enabled: connectionAcceptedEnabled,
+        connection_denied_enabled: connectionDeniedEnabled,
+        private_event_invitation_enabled: privateEventInvitationEnabled,
+        event_rsvp_updates_enabled: eventRsvpUpdatesEnabled,
+        public_event_announcements_enabled: publicEventAnnouncementsEnabled,
+        network_event_announcements_enabled: networkEventAnnouncementsEnabled,
+      });
+
+      setNotificationSettings({
         push_enabled: pushEnabled,
         important_enabled: importantEnabled,
         general_enabled: generalEnabled,

--- a/frontend/src/lib/api_client.ts
+++ b/frontend/src/lib/api_client.ts
@@ -331,3 +331,25 @@ export async function getNotificationSettings(accessToken: string) {
     throw err;
   }
 }
+
+export async function updateNotificationSettings(accessToken: string, newSettings: any) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/notifications/settings`, {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(newSettings),
+    });
+
+    if (!res.ok) {
+      throw new Error("Could not update notification settings");
+    }
+
+    return { success: true };
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}

--- a/frontend/src/lib/api_client.ts
+++ b/frontend/src/lib/api_client.ts
@@ -285,8 +285,11 @@ export async function fetchNotifications(accessToken: string) {
   }
 }
 
-
-export async function updateNotificationStatus(accessToken: string, notificationId:string, status:string) {
+export async function updateNotificationStatus(
+  accessToken: string,
+  notificationId: string,
+  status: string,
+) {
   try {
     const res = await fetch(`${API_BASE_URL}/api/notifications/${notificationId}`, {
       method: "PUT",
@@ -294,13 +297,35 @@ export async function updateNotificationStatus(accessToken: string, notification
         Authorization: `Bearer ${accessToken}`,
         "Content-Type": "application/json",
       },
-      body: JSON.stringify({status})
+      body: JSON.stringify({ status }),
     });
 
     if (!res.ok) {
       throw new Error("Could not update notification status");
     }
     return await res.json();
+  } catch (err) {
+    console.error(err);
+    throw err;
+  }
+}
+
+export async function getNotificationSettings(accessToken: string) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/notifications/settings`, {
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error("Could not fetch notification settings");
+    }
+
+    const data = await res.json();
+    return data.settings;
   } catch (err) {
     console.error(err);
     throw err;

--- a/frontend/src/lib/api_client.ts
+++ b/frontend/src/lib/api_client.ts
@@ -353,3 +353,23 @@ export async function updateNotificationSettings(accessToken: string, newSetting
     throw err;
   }
 }
+
+export async function postActivity(accessToken: string, activityType: any) {
+  try {
+    const res = await fetch(`${API_BASE_URL}/api/activity`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ activityType }),
+    });
+
+    if (!res.ok) {
+      throw new Error("Could not post an activity");
+    }
+  } catch (err) {
+    console.error("Could not log activity", err);
+    throw err;
+  }
+}

--- a/frontend/src/pages/CheckIfNewProfilePage/CheckIfNewProfilePage.tsx
+++ b/frontend/src/pages/CheckIfNewProfilePage/CheckIfNewProfilePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { useAuthContext } from "@/Context/AuthProvider";
 import ExtraInfoForm from "@/components/ExtraInfoForm/ExtraInfoForm";
 import { DASHBOARD_PATH } from "@/lib/paths";
+import { getNotificationSettings } from "@/lib/api_client";
 
 type ProfileFormData = {
   name: string;
@@ -16,7 +17,7 @@ export default function InitialRegisterSetupPage() {
   const navigate = useNavigate();
   const { session } = useAuthContext(); //this will grab the session and user from AuthContext since this is a protected page they will exist guaranteed
   const [checkingIfNewUser, setCheckingIfNewUser] = useState(true); //this by default is going to be true because we need to check if the user who just logged in is a new user or returning user
-
+  const { setNotificationSettings } = useAuthContext();
   //when form is Submitted this function gets called within form component and gets passed in all the form details. This functions job is to make fetch request to add user
   async function handleFormSubmit(data: ProfileFormData) {
     try {
@@ -33,6 +34,13 @@ export default function InitialRegisterSetupPage() {
       if (!res.ok) {
         const error = await res.json();
         throw new Error(error.message || "Failed to create profile after form submission");
+      }
+
+      try {
+        const settings = await getNotificationSettings(session!.access_token);
+        setNotificationSettings(settings);
+      } catch (error) {
+        console.error("Failed to load notification settings after profile creation:", error);
       }
 
       //otherwise it was succesful and user was added so just navigate them to the dashboard!!!!

--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -19,8 +19,6 @@ export default function DashboardPage() {
   const [showSettings, setShowSettings] = useState(false);
 
   //TODO: Remove later, leaving this here for now so that it is easier to test my apis. Whenever I test them since they have middleware I need to provide a token this is how I see and get that token.
-  console.log(session?.access_token);
-  console.log(session?.user);
 
 
   function handleSettingsClose(){

--- a/frontend/src/pages/DashboardPage/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage/DashboardPage.tsx
@@ -19,7 +19,7 @@ export default function DashboardPage() {
   const [showSettings, setShowSettings] = useState(false);
 
   //TODO: Remove later, leaving this here for now so that it is easier to test my apis. Whenever I test them since they have middleware I need to provide a token this is how I see and get that token.
-
+  console.log(session?.access_token);
 
   function handleSettingsClose(){
     setShowSettings(false);


### PR DESCRIPTION
_No images because it is seem filtering stuff just doing it on server now_

**This Pull Request**

P.S. I know client and server shouldn't be mixed but once again these changes went hand in hand for the testing of the filtering. Made a note of wha I did in each to help you!

Backend Changes
- Added seen_at TIMESTAMP column to notifications table
- GET /notifications: Now filters by user settings (types + priorities), auto-marks delivered notifications as "seen", returns only seen notifications
- PUT /notifications/:id: Simplified to handle status + seen_at updates, removed non-existent read_at field
- WebSocket filtering: Added shouldSendNotificationToUser() to check settings before sending, prevents disabled notifications from reaching frontend

Frontend Changes
- Removed frontend filtering: Deleted filterNotifications() function and notificationSettings usage
- Enhanced WebSocket: Auto-mark actionable notifications (connection_request, private_event_invitation) as "seen" when received
- Simplified component: Use notifications directly instead of filtered results

**Next Pull Request**
 Implement smart nudge scheduler for "seen" notifications older than 2 hours.