### PR TITLE
#72 enhancing tc1

### DIFF
--- a/backend/services/calculateMatchScore.js
+++ b/backend/services/calculateMatchScore.js
@@ -64,9 +64,10 @@ function calcAudienceScore(streamerToCompare, userWeights) {
 
 //refactored this function fully so that we can do smart tag checking based on user preference
 function calcTagScore(streamerToCompare, userWeights) {
+  //ehanced twitchtags now includes the current channels tags as well as tags labeled from past streams for better matchin
   const noDupTags = mergeAndDeduplicateTags(
     streamerToCompare.tags,
-    streamerToCompare.twitch_tags
+    streamerToCompare.twitch_tags //more enhanced data!
   );
 
   let totalPreference = 0; //going with an average approach so that users with more tags dont beat user with less amount of tags but better perfefnce to them
@@ -84,15 +85,24 @@ function calcTagScore(streamerToCompare, userWeights) {
 }
 
 function calcGameScore(currentUser, streamerToCompare) {
-  // Handle missing game data not all twitch users might have it most do though
-  if (!currentUser.twitch_game_name || !streamerToCompare.twitch_game_name) {
+  //now using enhanced userGames array
+  const userGames =
+    currentUser.twitch_games || [currentUser.twitch_game_name].filter(Boolean);
+  const streamerGames =
+    streamerToCompare.twitch_games ||
+    [streamerToCompare.twitch_game_name].filter(Boolean);
+
+  if (userGames.length === 0 || streamerGames.length === 0) {
     return 0.5; // Can't compare, return base score
   }
 
-  if (currentUser.twitch_game_name === streamerToCompare.twitch_game_name) {
-    return 2; // Same game
+  // Enhanced: Check for any game overlap between arrays
+  const gameOverlap = userGames.some((game) => streamerGames.includes(game));
+
+  if (gameOverlap) {
+    return 2; // Found matching game in their history
   } else {
-    return 0.5; // Different game
+    return 0.5; // No games in common
   }
 }
 

--- a/backend/services/grabTwitchInfo.js
+++ b/backend/services/grabTwitchInfo.js
@@ -114,12 +114,18 @@ async function processTwitchUserData(twitchUserId) {
     }
 
     const accessToken = await getTwitchAppAccessToken();
-    
+
     //lets get both channel info and stream history same tiem wiht promsie.all runs them in parallel
     const [channelInfo, streamHistory] = await Promise.all([
       getTwitchChannelData(twitchUserId, accessToken),
-      getTwitchStreamHistory(twitchUserId, accessToken)
+      getTwitchStreamHistory(twitchUserId, accessToken),
     ]);
+
+    //lets combine users most recent current game with history of games
+    const allGames = new Set(streamHistory.historyOfGames);
+    if (channelInfo?.twitch_game_name) {
+      allGames.add(channelInfo.twitch_game_name);
+    }
 
     //remember channelInfo coudl have null values if some fields werrent filled in that is ok not every user will have every field filled in
     return channelInfo;

--- a/backend/services/grabTwitchInfo.js
+++ b/backend/services/grabTwitchInfo.js
@@ -127,6 +127,12 @@ async function processTwitchUserData(twitchUserId) {
       allGames.add(channelInfo.twitch_game_name);
     }
 
+    //spread the channels tags as well as the tags applied to different streams into one thing
+    const allTags = new Set([
+      ...(channelInfo?.twitch_tags || []),
+      ...streamHistory.historyOfTags,
+    ]);
+
     //remember channelInfo coudl have null values if some fields werrent filled in that is ok not every user will have every field filled in
     return channelInfo;
   } catch (err) {

--- a/backend/services/grabTwitchInfo.js
+++ b/backend/services/grabTwitchInfo.js
@@ -106,7 +106,7 @@ async function getTwitchStreamHistory(twitchUserId, accessToken) {
   }
 }
 
-//this function calls the two functions above. getTwitchAccestoken so then use that result and call the get twitch data
+//this function calls the functions above. getTwitchAccestoken so then use that result and call the get twitch data as well as streamhistory
 async function processTwitchUserData(twitchUserId) {
   try {
     if (!twitchUserId) {
@@ -114,7 +114,12 @@ async function processTwitchUserData(twitchUserId) {
     }
 
     const accessToken = await getTwitchAppAccessToken();
-    const channelInfo = await getTwitchChannelData(twitchUserId, accessToken);
+    
+    //lets get both channel info and stream history same tiem wiht promsie.all runs them in parallel
+    const [channelInfo, streamHistory] = await Promise.all([
+      getTwitchChannelData(twitchUserId, accessToken),
+      getTwitchStreamHistory(twitchUserId, accessToken)
+    ]);
 
     //remember channelInfo coudl have null values if some fields werrent filled in that is ok not every user will have every field filled in
     return channelInfo;

--- a/backend/services/grabTwitchInfo.js
+++ b/backend/services/grabTwitchInfo.js
@@ -93,8 +93,17 @@ async function getTwitchStreamHistory(twitchUserId, accessToken) {
       }
     });
 
-    
-  } catch (err) {}
+    return {
+      historyOfGames: Array.from(games),
+      historyOfTags: Array.from(tags),
+    };
+  } catch (err) {
+    console.error(`Failed to get stream history:`, err);
+    return {
+      historyOfGames: [],
+      historyOfTags: [],
+    };
+  }
 }
 
 //this function calls the two functions above. getTwitchAccestoken so then use that result and call the get twitch data

--- a/backend/services/grabTwitchInfo.js
+++ b/backend/services/grabTwitchInfo.js
@@ -71,10 +71,30 @@ async function getTwitchStreamHistory(twitchUserId, accessToken) {
         },
       }
     );
-  } catch (err) {
 
-  }
-  
+    if (!res.ok) {
+      throw new Error(`Failed to get stream history: ${res.status}`);
+    }
+
+    const streamData = await res.json();
+    const streams = streamData.data || [];
+
+    //making sets for games and tags because across 20 streams if user played fornite we dont need to store 20 fortnites
+    const games = new Set();
+    const tags = new Set();
+
+    streams.forEach((stream) => {
+      if (stream.game_name) {
+        games.add(stream.game_name);
+      }
+
+      if (stream.tags && Array.isArray(stream.tags)) {
+        stream.tags.forEach((tag) => tags.add(tag.toLowerCase()));
+      }
+    });
+
+    
+  } catch (err) {}
 }
 
 //this function calls the two functions above. getTwitchAccestoken so then use that result and call the get twitch data

--- a/backend/services/grabTwitchInfo.js
+++ b/backend/services/grabTwitchInfo.js
@@ -60,6 +60,23 @@ async function getTwitchChannelData(twitchUserId, accessToken) {
   }
 }
 
+async function getTwitchStreamHistory(twitchUserId, accessToken) {
+  try {
+    const res = await fetch(
+      `https://api.twitch.tv/helix/streams?user_id=${twitchUserId}`,
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Client-Id": process.env.TWITCH_CLIENT_ID,
+        },
+      }
+    );
+  } catch (err) {
+
+  }
+  
+}
+
 //this function calls the two functions above. getTwitchAccestoken so then use that result and call the get twitch data
 async function processTwitchUserData(twitchUserId) {
   try {


### PR DESCRIPTION
_Example extra tags and data that helix/stream API pulled on login_

<img width="932" height="584" alt="PNG image" src="https://github.com/user-attachments/assets/b12ac257-f914-44d1-a31d-078d531c2818" />

**This Pull Request**
- Enhanced Twitch data collection by fetching stream history via /helix/streams API
- Added twitch_games array field to capture historical gaming preferences for improved matching
- Expanded twitch_tags to include tags from past streams for richer personality matching
- Updated calcGameScore() to compare game history arrays instead of single current game
- Enhanced calcTagScore() with comprehensive tag data from stream history

**Next Pull Request**
-  Fix the posting of user activity to be a post processing event not on the frontend.